### PR TITLE
Prevent success notification on ajax load

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -183,11 +183,16 @@ jQuery.noConflict();
 				$('.cms-container').showLoginDialog();
 				return;
 			}
-
+			
 			// Show message (but ignore aborted requests)
 			if(xhr.status !== 0 && msg && $.inArray(msg, ignoredMessages)) {
-				// Decode into UTF-8, HTTP headers don't allow multibyte
-				statusMessage(decodeURIComponent(msg), msgType);
+				if(xhr.status === 200 && msg === 'success') { 
+					// Ignore success message for successful requests
+				}
+				else {
+					// Decode into UTF-8, HTTP headers don't allow multibyte
+					statusMessage(decodeURIComponent(msg), msgType);
+				}
 			}
 
 			ajaxCompleteEvent(this);


### PR DESCRIPTION
This happens to me only on servers with nginx as a front server and with https enabled.

My fix may not be the most elegant but it works (basically, if status = 200, ignore "success" message). Maybe it should be necessary to investigate why this happens in the first place.
